### PR TITLE
Convert Next.js page to static HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Student Accommodation Cards</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/embla-carousel@8.1.0/embla-carousel.umd.js"></script>
+  <script src="https://unpkg.com/lucide@latest"></script>
+  <style>
+    :root {
+      --background: 330 11% 95%;
+      --foreground: 240 10% 3.9%;
+      --card: 0 0% 100%;
+      --card-foreground: 240 10% 3.9%;
+      --primary: 3 76% 42%;
+      --accent: 4 71% 62%;
+    }
+    body { font-family: 'Inter', sans-serif; }
+    .embla__viewport { overflow: hidden; width: 100%; }
+    .embla__container { display: flex; }
+    .embla__slide { flex: 0 0 80%; padding-left: 1rem; }
+  </style>
+</head>
+<body class="bg-[hsl(var(--background))] text-[hsl(var(--foreground))]">
+  <main class="min-h-screen container mx-auto py-8 px-4">
+    <header class="text-center mb-10">
+      <h1 class="text-4xl font-bold text-[hsl(var(--primary))] mb-2">Student Accommodation</h1>
+      <p class="text-lg text-gray-600">Find your perfect room at Nile &amp; Baze University.</p>
+    </header>
+
+    <div class="mb-8 bg-[hsl(var(--accent)/0.1)] border border-[hsl(var(--accent))] text-[hsl(var(--accent))] shadow-md p-4 rounded">
+      <p class="font-semibold">Special Offer for Returning Students!</p>
+      <p>All returning students get an automatic <span class="font-bold">10% discount</span> on accommodation fees. Welcome back!</p>
+    </div>
+
+    <section aria-labelledby="accommodation-options">
+      <h2 id="accommodation-options" class="sr-only">Available Accommodations</h2>
+      <div class="embla">
+        <div class="embla__viewport">
+          <div class="embla__container">
+            <div class="embla__slide p-1">
+              <div class="flex flex-col h-full overflow-hidden rounded-lg shadow-lg transition-shadow hover:shadow-xl bg-white">
+                <img src="https://placehold.co/600x400.png" alt="Image of Standard Single Room" class="w-full h-56 object-cover">
+                <div class="p-4 space-y-2 flex flex-col flex-grow">
+                  <h3 class="text-xl font-semibold">Standard Single Room</h3>
+                  <p class="text-sm">For Nile University Students</p>
+                  <p class="text-xs text-gray-500">A cozy single room perfect for focused study, available for Nile University students.</p>
+                  <p class="text-lg font-bold text-[hsl(var(--primary))]">₦120,000</p>
+                  <ul class="grid grid-cols-2 gap-1 text-xs">
+                    <li class="flex items-center"><i data-lucide="wifi" class="w-4 h-4 mr-1 text-[hsl(var(--primary))]"></i>WiFi</li>
+                    <li class="flex items-center"><i data-lucide="zap" class="w-4 h-4 mr-1 text-[hsl(var(--primary))]"></i>Power</li>
+                    <li class="flex items-center"><i data-lucide="sparkles" class="w-4 h-4 mr-1 text-[hsl(var(--primary))]"></i>Cleaning</li>
+                  </ul>
+                  <div class="mt-auto">
+                    <span class="text-xs border rounded px-2 py-1">Occupancy: 65%</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="embla__slide p-1">
+              <div class="flex flex-col h-full overflow-hidden rounded-lg shadow-lg transition-shadow hover:shadow-xl bg-white">
+                <img src="https://placehold.co/600x400.png" alt="Image of 2-Bedroom Shared Apartment" class="w-full h-56 object-cover">
+                <div class="p-4 space-y-2 flex flex-col flex-grow">
+                  <h3 class="text-xl font-semibold">2-Bedroom Shared Apartment</h3>
+                  <p class="text-sm">For Baze University Students</p>
+                  <p class="text-xs text-gray-500">Spacious shared apartment with modern amenities for Baze University students.</p>
+                  <p class="text-lg font-bold text-[hsl(var(--primary))]">₦180,000</p>
+                  <ul class="grid grid-cols-2 gap-1 text-xs">
+                    <li class="flex items-center"><i data-lucide="wifi" class="w-4 h-4 mr-1 text-[hsl(var(--primary))]"></i>WiFi</li>
+                    <li class="flex items-center"><i data-lucide="zap" class="w-4 h-4 mr-1 text-[hsl(var(--primary))]"></i>Power</li>
+                    <li class="flex items-center"><i data-lucide="shirt" class="w-4 h-4 mr-1 text-[hsl(var(--primary))]"></i>Laundry</li>
+                    <li class="flex items-center"><i data-lucide="sparkles" class="w-4 h-4 mr-1 text-[hsl(var(--primary))]"></i>Cleaning</li>
+                  </ul>
+                  <div class="mt-auto">
+                    <span class="text-xs border rounded px-2 py-1">Occupancy: 40%</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="embla__slide p-1">
+              <div class="flex flex-col h-full overflow-hidden rounded-lg shadow-lg transition-shadow hover:shadow-xl bg-white">
+                <img src="https://placehold.co/600x400.png" alt="Image of Deluxe Single Room" class="w-full h-56 object-cover">
+                <div class="p-4 space-y-2 flex flex-col flex-grow">
+                  <h3 class="text-xl font-semibold">Deluxe Single Room</h3>
+                  <p class="text-sm">For Nile University Students</p>
+                  <p class="text-xs text-gray-500">Premium single room with extra space and enhanced features at Nile University.</p>
+                  <p class="text-lg font-bold text-[hsl(var(--primary))]">₦150,000</p>
+                  <ul class="grid grid-cols-2 gap-1 text-xs">
+                    <li class="flex items-center"><i data-lucide="wifi" class="w-4 h-4 mr-1 text-[hsl(var(--primary))]"></i>WiFi</li>
+                    <li class="flex items-center"><i data-lucide="zap" class="w-4 h-4 mr-1 text-[hsl(var(--primary))]"></i>Power</li>
+                    <li class="flex items-center"><i data-lucide="shirt" class="w-4 h-4 mr-1 text-[hsl(var(--primary))]"></i>Laundry</li>
+                    <li class="flex items-center"><i data-lucide="sparkles" class="w-4 h-4 mr-1 text-[hsl(var(--primary))]"></i>Cleaning</li>
+                  </ul>
+                  <div class="mt-auto">
+                    <span class="text-xs border rounded px-2 py-1">Occupancy: 80%</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="embla__slide p-1">
+              <div class="flex flex-col h-full overflow-hidden rounded-lg shadow-lg transition-shadow hover:shadow-xl bg-white">
+                <img src="https://placehold.co/600x400.png" alt="Image of Studio Apartment" class="w-full h-56 object-cover">
+                <div class="p-4 space-y-2 flex flex-col flex-grow">
+                  <h3 class="text-xl font-semibold">Studio Apartment</h3>
+                  <p class="text-sm">For Baze University Students</p>
+                  <p class="text-xs text-gray-500">Self-contained studio apartment offering privacy and comfort for Baze students.</p>
+                  <p class="text-lg font-bold text-[hsl(var(--primary))]">₦220,000</p>
+                  <ul class="grid grid-cols-2 gap-1 text-xs">
+                    <li class="flex items-center"><i data-lucide="wifi" class="w-4 h-4 mr-1 text-[hsl(var(--primary))]"></i>WiFi</li>
+                    <li class="flex items-center"><i data-lucide="zap" class="w-4 h-4 mr-1 text-[hsl(var(--primary))]"></i>Power</li>
+                    <li class="flex items-center"><i data-lucide="sparkles" class="w-4 h-4 mr-1 text-[hsl(var(--primary))]"></i>Cleaning</li>
+                    <li class="flex items-center"><i data-lucide="shirt" class="w-4 h-4 mr-1 text-[hsl(var(--primary))]"></i>Laundry</li>
+                  </ul>
+                  <div class="mt-auto">
+                    <span class="text-xs border rounded px-2 py-1">Occupancy: 55%</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="embla__slide p-1">
+              <div class="flex flex-col h-full overflow-hidden rounded-lg shadow-lg transition-shadow hover:shadow-xl bg-white">
+                <img src="https://placehold.co/600x400.png" alt="Image of Shared Twin Room" class="w-full h-56 object-cover">
+                <div class="p-4 space-y-2 flex flex-col flex-grow">
+                  <h3 class="text-xl font-semibold">Shared Twin Room</h3>
+                  <p class="text-sm">For Nile University Students</p>
+                  <p class="text-xs text-gray-500">Affordable shared twin room for students at Nile University seeking a communal experience.</p>
+                  <p class="text-lg font-bold text-[hsl(var(--primary))]">₦90,000</p>
+                  <ul class="grid grid-cols-2 gap-1 text-xs">
+                    <li class="flex items-center"><i data-lucide="wifi" class="w-4 h-4 mr-1 text-[hsl(var(--primary))]"></i>WiFi</li>
+                    <li class="flex items-center"><i data-lucide="zap" class="w-4 h-4 mr-1 text-[hsl(var(--primary))]"></i>Power</li>
+                  </ul>
+                  <div class="mt-auto">
+                    <span class="text-xs border rounded px-2 py-1">Occupancy: 90%</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="embla__slide p-1">
+              <div class="flex flex-col h-full overflow-hidden rounded-lg shadow-lg transition-shadow hover:shadow-xl bg-white">
+                <img src="https://placehold.co/600x400.png" alt="Image of Premium Single Suite" class="w-full h-56 object-cover">
+                <div class="p-4 space-y-2 flex flex-col flex-grow">
+                  <h3 class="text-xl font-semibold">Premium Single Suite</h3>
+                  <p class="text-sm">For Baze University Students</p>
+                  <p class="text-xs text-gray-500">Exclusive single suite with top-tier amenities for discerning Baze University students.</p>
+                  <p class="text-lg font-bold text-[hsl(var(--primary))]">₦250,000</p>
+                  <ul class="grid grid-cols-2 gap-1 text-xs">
+                    <li class="flex items-center"><i data-lucide="wifi" class="w-4 h-4 mr-1 text-[hsl(var(--primary))]"></i>WiFi</li>
+                    <li class="flex items-center"><i data-lucide="zap" class="w-4 h-4 mr-1 text-[hsl(var(--primary))]"></i>Power</li>
+                    <li class="flex items-center"><i data-lucide="shirt" class="w-4 h-4 mr-1 text-[hsl(var(--primary))]"></i>Laundry</li>
+                    <li class="flex items-center"><i data-lucide="sparkles" class="w-4 h-4 mr-1 text-[hsl(var(--primary))]"></i>Cleaning</li>
+                  </ul>
+                  <div class="mt-auto">
+                    <span class="text-xs border rounded px-2 py-1">Occupancy: 30%</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <footer class="text-center mt-12 pt-8 border-t">
+      <p class="text-sm text-gray-600">&copy; 2024 Student Accommodation Services. All rights reserved.</p>
+    </footer>
+  </main>
+
+  <script>
+    lucide.createIcons();
+    const emblaNode = document.querySelector('.embla');
+    const viewport = emblaNode.querySelector('.embla__viewport');
+    const embla = EmblaCarousel(viewport, { loop: true });
+    setInterval(() => {
+      if (embla.canScrollNext()) {
+        embla.scrollNext();
+      } else {
+        embla.scrollTo(0);
+      }
+    }, 5000);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `index.html` that mirrors the main Next.js page using CDN Tailwind, Embla Carousel and Lucide icons

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails to resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_685166ec372c832ea9d0e5be7c1639bc